### PR TITLE
feat: add privacy policy page

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -24,7 +24,7 @@ const madeBy = t(`footer.made-by`)
 
     <p>&copy; Rubens Lopes, {year}.</p>
 
-    <a href={`/${Astro.currentLocale}/privacy-policy`}>{t('footer.privacy-policy-label')}</a>
+    <a href={`/${Astro.currentLocale ?? 'en'}/privacy-policy`}>{t('footer.privacy-policy-label')}</a>
 
     <div set:html={madeBy} class="self-start" />
   </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -23,7 +23,9 @@ const madeBy = t(`footer.made-by`)
     <SocialMedias />
 
     <p>&copy; Rubens Lopes, {year}.</p>
-  
+
+    <a href={`/${Astro.currentLocale}/privacy-policy`}>{t('footer.privacy-policy-label')}</a>
+
     <div set:html={madeBy} class="self-start" />
   </div>
 

--- a/src/i18n/footer.ts
+++ b/src/i18n/footer.ts
@@ -4,11 +4,13 @@ export const footer = {
     'footer.email-label': `Talk to me`,
     'footer.linked-in-label': `My LinkedIn profile`,
     'footer.github-label': `My GitHub profile`,
+    'footer.privacy-policy-label': `Privacy Policy`,
   },
   'pt-br': {
     'footer.made-by': `Design por {0} e {1}. Desenvolvido por mim.`,
     'footer.email-label': `Fale comigo`,
     'footer.linked-in-label': `Meu perfil no LinkedIn`,
     'footer.github-label': `Meu perfil no GitHub`,
+    'footer.privacy-policy-label': `Política de Privacidade`,
   },
 }

--- a/src/i18n/privacy-policy.ts
+++ b/src/i18n/privacy-policy.ts
@@ -1,0 +1,46 @@
+export const privacyPolicy = {
+  en: {
+    'privacy-policy.title': `Privacy Policy`,
+    'privacy-policy.last-updated': `Last updated: March 17, 2026`,
+
+    'privacy-policy.section.controller.heading': `Data Controller`,
+    'privacy-policy.section.controller.body': `Rubens Lopes is the data controller for this website. You can reach him at <a href="mailto:contact@rubenslopes.es">contact@rubenslopes.es</a>.`,
+
+    'privacy-policy.section.data.heading': `Data We Collect`,
+    'privacy-policy.section.data.body': `This site collects anonymous, aggregated usage data through <strong>Vercel Analytics</strong> (page views, referrers, and country-level location) and anonymous performance metrics through <strong>Vercel Speed Insights</strong> (page load times). No personal identifiers are collected. No analytics cookies are set.`,
+
+    'privacy-policy.section.cookies.heading': `Cookies`,
+    'privacy-policy.section.cookies.body': `This site uses two functional cookies: <code>lang</code> stores your language preference, and <code>theme</code> stores your dark or light mode preference. No tracking, advertising, or profiling cookies are used.`,
+
+    'privacy-policy.section.third-party.heading': `Third-Party Services`,
+    'privacy-policy.section.third-party.body': `This site is hosted on <strong>Vercel</strong>, which provides infrastructure, analytics, and performance monitoring. See <a href="https://vercel.com/legal/privacy-policy">Vercel's Privacy Policy</a> for details on how Vercel processes data.`,
+
+    'privacy-policy.section.contact.heading': `Contact Channels`,
+    'privacy-policy.section.contact.body': `You may contact Rubens via email at <a href="mailto:contact@rubenslopes.es">contact@rubenslopes.es</a> or through WhatsApp. Messages are used solely to reply and are not stored, shared, or processed beyond the conversation.`,
+
+    'privacy-policy.section.rights.heading': `Your Rights`,
+    'privacy-policy.section.rights.body': `Under <strong>GDPR</strong> (EU/EEA) and <strong>LGPD</strong> (Brazil), you have the right to access, correct, or delete any personal data held about you. To exercise these rights, contact <a href="mailto:contact@rubenslopes.es">contact@rubenslopes.es</a>.`,
+  },
+  'pt-br': {
+    'privacy-policy.title': `Política de Privacidade`,
+    'privacy-policy.last-updated': `Última atualização: 17 de março de 2026`,
+
+    'privacy-policy.section.controller.heading': `Responsável pelo Tratamento`,
+    'privacy-policy.section.controller.body': `Rubens Lopes é o responsável pelo tratamento de dados deste site. Você pode entrar em contato pelo e-mail <a href="mailto:contact@rubenslopes.es">contact@rubenslopes.es</a>.`,
+
+    'privacy-policy.section.data.heading': `Dados que Coletamos`,
+    'privacy-policy.section.data.body': `Este site coleta dados de uso anônimos e agregados por meio do <strong>Vercel Analytics</strong> (visualizações de página, referenciadores e localização por país) e métricas de desempenho anônimas por meio do <strong>Vercel Speed Insights</strong> (tempos de carregamento de página). Nenhum identificador pessoal é coletado. Nenhum cookie de análise é definido.`,
+
+    'privacy-policy.section.cookies.heading': `Cookies`,
+    'privacy-policy.section.cookies.body': `Este site utiliza dois cookies funcionais: <code>lang</code> armazena sua preferência de idioma, e <code>theme</code> armazena sua preferência de modo claro ou escuro. Nenhum cookie de rastreamento, publicidade ou criação de perfil é utilizado.`,
+
+    'privacy-policy.section.third-party.heading': `Serviços de Terceiros`,
+    'privacy-policy.section.third-party.body': `Este site é hospedado na <strong>Vercel</strong>, que fornece infraestrutura, análises e monitoramento de desempenho. Consulte a <a href="https://vercel.com/legal/privacy-policy">Política de Privacidade da Vercel</a> para detalhes sobre como a Vercel processa dados.`,
+
+    'privacy-policy.section.contact.heading': `Canais de Contato`,
+    'privacy-policy.section.contact.body': `Você pode entrar em contato com Rubens por e-mail em <a href="mailto:contact@rubenslopes.es">contact@rubenslopes.es</a> ou pelo WhatsApp. As mensagens são utilizadas exclusivamente para responder e não são armazenadas, compartilhadas ou processadas além da conversa.`,
+
+    'privacy-policy.section.rights.heading': `Seus Direitos`,
+    'privacy-policy.section.rights.body': `De acordo com o <strong>GDPR</strong> (UE/EEE) e a <strong>LGPD</strong> (Brasil), você tem o direito de acessar, corrigir ou excluir quaisquer dados pessoais mantidos sobre você. Para exercer esses direitos, entre em contato com <a href="mailto:contact@rubenslopes.es">contact@rubenslopes.es</a>.`,
+  },
+}

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -1,16 +1,19 @@
 import { about } from './about'
 import { footer } from './footer'
 import { controls } from './controls'
+import { privacyPolicy } from './privacy-policy'
 
 export const ui = {
   en: {
     ...about.en,
     ...footer.en,
     ...controls.en,
+    ...privacyPolicy.en,
   },
   'pt-br': {
     ...about['pt-br'],
     ...footer['pt-br'],
     ...controls['pt-br'],
+    ...privacyPolicy['pt-br'],
   },
 }

--- a/src/pages/[lang]/privacy-policy.astro
+++ b/src/pages/[lang]/privacy-policy.astro
@@ -1,0 +1,104 @@
+---
+import SpeedInsights from '@vercel/speed-insights/astro'
+import Header from '$components/Header.astro'
+import Footer from '$components/Footer.astro'
+import '$styles/global.css'
+import { useTranslations } from '$i18n/utils'
+
+const lang = Astro.currentLocale ?? 'en'
+const validLocales = ['en', 'pt-br']
+if (!validLocales.includes(lang)) {
+  return Astro.redirect('/en/privacy-policy')
+}
+const t = useTranslations(lang as 'en' | 'pt-br')
+---
+
+<script is:inline>
+function getTheme() {
+  return typeof localStorage !== `undefined` && `theme` in localStorage
+    ? localStorage.getItem(`theme`)
+    : getPrefersColorScheme()
+}
+
+function getPrefersColorScheme() {
+  if (typeof window === `undefined`) return ``
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? `dark`
+    : ``
+}
+
+function lightsOut() {
+  typeof document !== `undefined` && document.documentElement.classList.add(`dark`)
+  if (typeof localStorage !== `undefined`) localStorage.theme = `dark`
+}
+
+function letThereBeLight() {
+  typeof document !== `undefined` && document.documentElement.classList.remove(`dark`)
+  if (typeof localStorage !== `undefined`) localStorage.theme = `light`
+}
+
+getTheme() === `light` ? letThereBeLight() : lightsOut()
+</script>
+
+<html lang={lang === 'pt-br' ? 'pt-BR' : lang} class="font-figtree bg-metallic-red">
+	<head>
+		<link rel="preconnect" href="https://fonts.googleapis.com">
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+		<link href="https://fonts.googleapis.com/css2?family=Figtree:ital,wght@0,300..900;1,300..900&display=swap" rel="stylesheet">
+
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width" />
+		<meta name="generator" content={Astro.generator} />
+
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+
+		<title>{t('privacy-policy.title')} — Rubens Lopes &lt;Software Engineer /&gt;</title>
+	</head>
+
+	<body class="bg-snow dark:bg-dark-gunmetal text-lg text-eerie-black dark:text-white">
+		<div class="flex min-h-screen flex-col items-center">
+			<Header />
+
+			<content class="flex-1">
+				<div class="container mx-auto py-12 space-y-8">
+					<h1 class="text-2xl font-bold">{t('privacy-policy.title')}</h1>
+					<p class="text-taupe-gray">{t('privacy-policy.last-updated')}</p>
+
+					<section class="space-y-3">
+						<h2 class="text-xl font-semibold">{t('privacy-policy.section.controller.heading')}</h2>
+						<p set:html={t('privacy-policy.section.controller.body')} />
+					</section>
+
+					<section class="space-y-3">
+						<h2 class="text-xl font-semibold">{t('privacy-policy.section.data.heading')}</h2>
+						<p set:html={t('privacy-policy.section.data.body')} />
+					</section>
+
+					<section class="space-y-3">
+						<h2 class="text-xl font-semibold">{t('privacy-policy.section.cookies.heading')}</h2>
+						<p set:html={t('privacy-policy.section.cookies.body')} />
+					</section>
+
+					<section class="space-y-3">
+						<h2 class="text-xl font-semibold">{t('privacy-policy.section.third-party.heading')}</h2>
+						<p set:html={t('privacy-policy.section.third-party.body')} />
+					</section>
+
+					<section class="space-y-3">
+						<h2 class="text-xl font-semibold">{t('privacy-policy.section.contact.heading')}</h2>
+						<p set:html={t('privacy-policy.section.contact.body')} />
+					</section>
+
+					<section class="space-y-3">
+						<h2 class="text-xl font-semibold">{t('privacy-policy.section.rights.heading')}</h2>
+						<p set:html={t('privacy-policy.section.rights.body')} />
+					</section>
+				</div>
+			</content>
+
+			<Footer />
+		</div>
+		<SpeedInsights />
+	</body>
+</html>

--- a/src/pages/[lang]/privacy-policy.astro
+++ b/src/pages/[lang]/privacy-policy.astro
@@ -60,8 +60,8 @@ getTheme() === `light` ? letThereBeLight() : lightsOut()
 		<div class="flex min-h-screen flex-col items-center">
 			<Header />
 
-			<content class="flex-1">
-				<div class="container mx-auto py-12 space-y-8">
+			<main class="flex-1">
+				<div class="container mx-auto py-12 space-y-8 max-w-prose">
 					<h1 class="text-2xl font-bold">{t('privacy-policy.title')}</h1>
 					<p class="text-taupe-gray">{t('privacy-policy.last-updated')}</p>
 
@@ -95,7 +95,7 @@ getTheme() === `light` ? letThereBeLight() : lightsOut()
 						<p set:html={t('privacy-policy.section.rights.body')} />
 					</section>
 				</div>
-			</content>
+			</main>
 
 			<Footer />
 		</div>


### PR DESCRIPTION
## Summary

- Adds bilingual \`/en/privacy-policy\` and \`/pt-br/privacy-policy\` pages following the existing \`[lang]\` routing pattern
- Covers GDPR/LGPD requirements: data controller, Vercel Analytics/Speed Insights disclosure, functional cookies (\`lang\`, \`theme\`), WhatsApp as contact-only channel, and user rights
- Adds a "Privacy Policy" / "Política de Privacidade" link to the footer in both locales

## Test Plan

- [ ] \`/en/privacy-policy\` returns 200 with English content
- [ ] \`/pt-br/privacy-policy\` returns 200 with Portuguese content
- [ ] \`/privacy-policy\` redirects to locale-appropriate page
- [ ] Footer link visible and correct on homepage in both locales
- [ ] Dark mode renders correctly on the policy page
- [ ] Meta WhatsApp Business review URL: \`https://rubenslop.es/en/privacy-policy\`