### PR TITLE
fix: preserve current page when switching languages

### DIFF
--- a/src/components/Lang.astro
+++ b/src/components/Lang.astro
@@ -7,8 +7,9 @@ const {
 } = Astro.props
 
 const active = Astro.currentLocale === lang ? `bg-metallic-red dark:bg-onyx` : ``
+const subpath = Astro.url.pathname.replace(/^\/[^/]+/, '')
 ---
-<a class:list={[active, `py-2 px-3 rounded-md`]} {title} aria-label={title} href={`/${lang}`}>
+<a class:list={[active, `py-2 px-3 rounded-md`]} {title} aria-label={title} href={`/${lang}${subpath}`}>
   <Icon name={lang} class="rounded-full size-6" />
 </a>
 


### PR DESCRIPTION
## Summary

- When switching languages, the user now stays on the current page instead of being redirected to the home page
- Fix is in `Lang.astro`: use `Astro.url.pathname` to extract the sub-path after the locale prefix, then append it to the target locale href

**Before:** `/en/privacy-policy` → switch to PT-BR → `/pt-br` (home)
**After:** `/en/privacy-policy` → switch to PT-BR → `/pt-br/privacy-policy`

## Test Plan

- [ ] On `/en/privacy-policy`, switch to PT-BR → lands on `/pt-br/privacy-policy`
- [ ] On `/pt-br/privacy-policy`, switch to EN → lands on `/en/privacy-policy`
- [ ] On homepage (`/en`), switch to PT-BR → lands on `/pt-br` (unchanged behavior)